### PR TITLE
WIP Implement ERC2126 for signed messages and validation

### DIFF
--- a/packages/provider/src/abi/erc1271.ts
+++ b/packages/provider/src/abi/erc1271.ts
@@ -1,0 +1,26 @@
+export const abi = [
+  {
+    type: 'function',
+    name: 'isValidSignature',
+    constant: true,
+    inputs: [
+      {
+        type: 'bytes32'
+      },
+      {
+        type: 'bytes'
+      }
+    ],
+    outputs: [
+      {
+        type: 'bytes4'
+      }
+    ],
+    payable: false,
+    stateMutability: 'view'
+  }
+]
+
+export const returns = {
+  isValidSignatureBytes32: '0x20c13b0b'
+}

--- a/packages/provider/src/relayer/local_relayer.ts
+++ b/packages/provider/src/relayer/local_relayer.ts
@@ -38,6 +38,6 @@ export class LocalRelayer {
     const walletModule = mainModule.attach(wallet).connect(this.signer)
 
     const nonce = readArcadeumNonce(...transactions)
-    return walletModule.execute(arcadeumTxAbiEncode(transactions), nonce, signature)
+    return walletModule.execute(arcadeumTxAbiEncode(transactions), nonce, (await signature).slice(0, -2))
   }
 }

--- a/packages/provider/src/wallet.ts
+++ b/packages/provider/src/wallet.ts
@@ -169,7 +169,7 @@ export class Wallet extends AbstractSigner {
     return ethers.utils.solidityPack(
       ['uint16', ...Array(this.config.signers.length).fill('bytes')],
       [this.config.threshold, ...accountBytes]
-    )
+    ) + '04'
   }
 
   static async singleOwner(context: ArcadeumContext, owner: Arrayish | AbstractSigner): Promise<Wallet> {

--- a/packages/provider/tests/wallet.spec.ts
+++ b/packages/provider/tests/wallet.spec.ts
@@ -166,7 +166,7 @@ describe('Arcadeum wallet integration', function () {
             await relayer.deploy(wallet.config, context)
 
             const digest = ethers.utils.hashMessage(message)
-            const call = hookCaller.callERC1271isValidSignatureData(wallet.address, digest, signature)
+            const call = hookCaller.callERC1271isValidSignatureData(wallet.address, digest, signature.slice(0, -2))
             await expect(call).to.be.fulfilled
           })
         })
@@ -472,7 +472,7 @@ describe('Arcadeum wallet integration', function () {
         await relayer.deploy(wallet.config, context)
 
         const digest = ethers.utils.hashMessage(ethers.utils.toUtf8Bytes(message))
-        const call = hookCaller.callERC1271isValidSignatureData(wallet.address, digest, signature)
+        const call = hookCaller.callERC1271isValidSignatureData(wallet.address, digest, signature.slice(0, -2))
         await expect(call).to.be.fulfilled
       })
 

--- a/packages/provider/tests/wallet.unit.spec.ts
+++ b/packages/provider/tests/wallet.unit.spec.ts
@@ -48,7 +48,7 @@ describe('Arcadeum wallet', function() {
       const pk = '0x87306d4b9fe56c2af23c7cc3bc69914eba8f7c8fc1d35b4c9a7dd7ea198a428b'
       const wallet = new arcadeum.Wallet(config, context, pk)
 
-      const expected = '0x0001000173cb0485449f375942c864e14ebd3b21ae2f3b40a8a6aee4c1e54f026f9a02c27f648bc6304d85745836ee1a7569ae1c83caa600030b91762da1fe5330b394981b02'
+      const expected = '0x0001000173cb0485449f375942c864e14ebd3b21ae2f3b40a8a6aee4c1e54f026f9a02c27f648bc6304d85745836ee1a7569ae1c83caa600030b91762da1fe5330b394981b0204'
       expect(await wallet.sign(digest)).to.equal(expected)
     })
     it('Should sign and recover the configuration of a single signer', async () => {
@@ -59,6 +59,7 @@ describe('Arcadeum wallet', function() {
       const chainId = 3
 
       const sig = await wallet.signMessage(message, chainId)
+
       const digest = encodeMessageData(wallet.address, chainId, ethers.utils.hashMessage(ethers.utils.arrayify(message)))
       const recovered = recoverConfig(digest, sig)
 


### PR DESCRIPTION
- Appends the type of signature at the end of each signed message
- Local relayer strips the type of the signature prior relaying
- Implement `isValidSignature` util method

TODO: Test `isValidSignature`