### PR TITLE
Fix double hash and implement isValidSignature

### DIFF
--- a/packages/provider/src/abi/erc1271.ts
+++ b/packages/provider/src/abi/erc1271.ts
@@ -1,0 +1,26 @@
+export const abi = [
+  {
+    type: 'function',
+    name: 'isValidSignature',
+    constant: true,
+    inputs: [
+      {
+        type: 'bytes32'
+      },
+      {
+        type: 'bytes'
+      }
+    ],
+    outputs: [
+      {
+        type: 'bytes4'
+      }
+    ],
+    payable: false,
+    stateMutability: 'view'
+  }
+]
+
+export const returns = {
+  isValidSignatureBytes32: '0x1626ba7e'
+}

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -128,19 +128,20 @@ export async function isValidSignature(
 
   const wallets = await Promise.all([
     isValidWalletSignature(address, digest, sig, provider),
-    isValidArcadeumWalletSignature(address, digest, sig, provider, chainId)
+    isValidArcadeumDeployedWalletSignature(address, digest, sig, provider, chainId)
   ])
 
   // If validity of wallet signature can't be determined
   // it could be a signature of a non-deployed arcadeum wallet
   if (wallets[0] === undefined && wallets[1] === undefined) {
-    return isValidArcadeumFixedSignature(address, digest, sig, arcadeumContext, provider, chainId)
+    return isValidArcadeumUndeployedWalletSignature(address, digest, sig, arcadeumContext, provider, chainId)
   }
 
   return wallets[0] || wallets[1]
 }
 
-export function isValidEIP721Signature(  address: string,
+export function isValidEIP721Signature(
+  address: string,
   digest: Uint8Array,
   sig: string
 ): boolean {
@@ -202,7 +203,7 @@ export async function isValidWalletSignature(
   }
 }
 
-export async function isValidArcadeumWalletSignature(
+export async function isValidArcadeumDeployedWalletSignature(
   address: string,
   digest: Uint8Array,
   sig: string,
@@ -219,7 +220,7 @@ export async function isValidArcadeumWalletSignature(
   }
 }
 
-export async function isValidArcadeumFixedSignature(
+export async function isValidArcadeumUndeployedWalletSignature(
   address: string,
   digest: Uint8Array,
   sig: string,

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -128,7 +128,7 @@ export async function isValidSignature(
 
   const wallets = await Promise.all([
     isValidWalletSignature(address, digest, sig, provider),
-    isValidArcadeumWalletSignature(address, digest, sig, provider)
+    isValidArcadeumWalletSignature(address, digest, sig, provider, chainId)
   ])
 
   // If validity of wallet signature can't be determined
@@ -206,12 +206,13 @@ export async function isValidArcadeumWalletSignature(
   address: string,
   digest: Uint8Array,
   sig: string,
-  provider?: Provider
+  provider?: Provider,
+  chainId?: number
 ) {
   if (!provider) return undefined // Signature validity can't be determined
   try {
-    const chainId = (await provider.getNetwork()).chainId
-    const subDigest = ethers.utils.arrayify(ethers.utils.keccak256(encodeMessageData(address, chainId, digest)))
+    const cid = chainId ? chainId : (await provider.getNetwork()).chainId
+    const subDigest = ethers.utils.arrayify(ethers.utils.keccak256(encodeMessageData(address, cid, digest)))
     return isValidWalletSignature(address, subDigest, sig, provider)
   } catch {
     return false

--- a/packages/provider/src/wallet.ts
+++ b/packages/provider/src/wallet.ts
@@ -136,13 +136,13 @@ export class Wallet extends AbstractSigner {
     return this.sign(digest)
   }
 
-  async signMessage(message: string, chainId?: number): Promise<string> {
+  async signMessage(message: Arrayish, chainId?: number): Promise<string> {
     return this.sign(
       ethers.utils.keccak256(
         encodeMessageData(
           this.address,
           chainId ? chainId : await this.chainId(),
-          ethers.utils.hashMessage(ethers.utils.arrayify(message))
+          ethers.utils.keccak256(message)
         )
       )
     )

--- a/packages/provider/tests/utils.unit.spec.ts
+++ b/packages/provider/tests/utils.unit.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import { ethers } from 'ethers'
 
 import * as arcadeum from '../src'
+import { isValidSignature, isValidEthSignSignature } from '../src/utils'
 
 describe('Arcadeum utils', function () {
   it('Should generate image hash', () => {

--- a/packages/provider/tests/wallet.spec.ts
+++ b/packages/provider/tests/wallet.spec.ts
@@ -13,6 +13,7 @@ import { Signer as AbstractSigner } from 'ethers'
 
 import * as chaiAsPromised from 'chai-as-promised'
 import * as chai from 'chai'
+import { isValidSignature, isValidEthSignSignature, encodeMessageData, isValidWalletSignature, isValidArcadeumWalletSignature, isValidArcadeumFixedSignature } from '../src/utils'
 
 const CallReceiverMockArtifact = require('arcadeum-wallet/build/contracts/CallReceiverMock.json')
 const HookCallerMockArtifact = require('arcadeum-wallet/build/contracts/HookCallerMock.json')
@@ -158,15 +159,14 @@ describe('Arcadeum wallet integration', function () {
 
         describe('signing', async () => {
           it('Should sign a message', async () => {
-            const message = ethers.utils.arrayify(ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hi! this is a test message')))
+            const message = ethers.utils.toUtf8Bytes('Hi! this is a test message')
 
             const signature = await signer.signMessage(message)
 
             // Contract wallet must be deployed before calling ERC1271
             await relayer.deploy(wallet.config, context)
 
-            const digest = ethers.utils.hashMessage(message)
-            const call = hookCaller.callERC1271isValidSignatureData(wallet.address, digest, signature)
+            const call = hookCaller.callERC1271isValidSignatureData(wallet.address, message, signature)
             await expect(call).to.be.fulfilled
           })
         })
@@ -471,8 +471,7 @@ describe('Arcadeum wallet integration', function () {
         // Contract wallet must be deployed before calling ERC1271
         await relayer.deploy(wallet.config, context)
 
-        const digest = ethers.utils.hashMessage(ethers.utils.toUtf8Bytes(message))
-        const call = hookCaller.callERC1271isValidSignatureData(wallet.address, digest, signature)
+        const call = hookCaller.callERC1271isValidSignatureData(wallet.address, ethers.utils.toUtf8Bytes(message), signature)
         await expect(call).to.be.fulfilled
       })
 
@@ -686,6 +685,92 @@ describe('Arcadeum wallet integration', function () {
         expect(await callReceiver1.lastValB()).to.equal('0x112233')
         expect(await callReceiver2.lastValB()).to.equal('0x445566')
         expect(await callReceiver3.lastValB()).to.equal('0x778899')
+      })
+    })
+  })
+
+  describe('Validate signatures', () => {
+    const message = ethers.utils.toUtf8Bytes('Hi! this is a test message')
+    const digest = ethers.utils.arrayify(ethers.utils.keccak256(message))
+
+    // TODO: Test EIP712 Sign
+
+    describe('ethSign', () => {
+      it('Should validate ethSign signature', async () => {
+        const signer = new ethers.Wallet(ethers.utils.randomBytes(32))
+        const signature = await signer.signMessage(digest)
+        expect(await isValidSignature(signer.address, digest, signature)).to.be.true
+      })
+      it('Should validate ethSign signature using direct method', async () => {
+        const signer = new ethers.Wallet(ethers.utils.randomBytes(32))
+        const signature = await signer.signMessage(digest)
+        expect(isValidEthSignSignature(signer.address, digest, signature)).to.be.true
+      })
+      it('Should reject invalid ethSign signature using direct method', async () => {
+        const signer1 = new ethers.Wallet(ethers.utils.randomBytes(32))
+        const signer2 = new ethers.Wallet(ethers.utils.randomBytes(32))
+        const signature = await signer1.signMessage(digest)
+        expect(await isValidSignature(signer2.address, digest, signature, ganache.provider, context)).to.be.false
+      })
+    })
+    describe('deployed arcadeum wallet sign', async () => {
+      it('Should validate arcadeum wallet signature', async () => {
+        const signature = await wallet.signMessage(message, 1)
+        await relayer.deploy(wallet.config, context)
+        expect(await isValidSignature(wallet.address, digest, signature, ganache.provider)).to.be.true
+      })
+      it('Should validate arcadeum wallet signature using direct method', async () => {
+        const signature = await wallet.signMessage(message, 1)
+        await relayer.deploy(wallet.config, context)
+        expect(await isValidArcadeumWalletSignature(wallet.address, digest, signature, ganache.provider)).to.be.true
+      })
+      it('Should reject arcadeum wallet invalid signature', async () => {
+        const wallet2 = await arcadeum.Wallet.singleOwner(context, new ethers.Wallet(ethers.utils.randomBytes(32)))
+        const signature = await wallet2.signMessage(message, 1)
+        await relayer.deploy(wallet.config, context)
+        expect(await isValidSignature(wallet.address, digest, signature, ganache.provider, context)).to.be.false
+      })
+      describe('After updating the owners', () => {
+        // TODO: Test signature should be invalidated if owners change
+      })
+    })
+    describe('non-deployed arcadeum wallet sign', async () => {
+      it('Should validate arcadeum wallet signature', async () => {
+        const signature = await wallet.signMessage(message, 1)
+        expect(await isValidSignature(wallet.address, digest, signature, ganache.provider, context)).to.be.true
+      })
+      it('Should validate arcadeum wallet signature using direct method', async () => {
+        const signature = await wallet.signMessage(message, 1)
+        expect(await isValidArcadeumFixedSignature(wallet.address, digest, signature, context, ganache.provider)).to.be.true
+      })
+      it('Should reject arcadeum wallet invalid signature', async () => {
+        const wallet2 = await arcadeum.Wallet.singleOwner(context, new ethers.Wallet(ethers.utils.randomBytes(32)))
+        const signature = await wallet2.signMessage(message, 1)
+        expect(await isValidSignature(wallet.address, digest, signature, ganache.provider, context)).to.be.false
+      })
+      describe('After updating the owners', () => {
+        // TODO: Test signature should be invalidated if owners change
+      })
+    })
+    describe('deployed wallet sign', () => {
+      it('Should validate wallet signature', async () => {
+        const signature = await wallet.signMessage(message, 1)
+        const subDigest = ethers.utils.arrayify(ethers.utils.keccak256(encodeMessageData(wallet.address, 1, digest)))
+        await relayer.deploy(wallet.config, context)
+        expect(await isValidSignature(wallet.address, subDigest, signature, ganache.provider)).to.be.true
+      })
+      it('Should validate wallet signature using direct method', async () => {
+        const signature = await wallet.signMessage(message, 1)
+        const subDigest = ethers.utils.arrayify(ethers.utils.keccak256(encodeMessageData(wallet.address, 1, digest)))
+        await relayer.deploy(wallet.config, context)
+        expect(await isValidWalletSignature(wallet.address, subDigest, signature, ganache.provider)).to.be.true
+      })
+      it('Should reject invalid wallet signature', async () => {
+        const wallet2 = await arcadeum.Wallet.singleOwner(context, new ethers.Wallet(ethers.utils.randomBytes(32)))
+        const signature = await wallet2.signMessage(message, 1)
+        const subDigest = ethers.utils.arrayify(ethers.utils.keccak256(encodeMessageData(wallet.address, 1, digest)))
+        await relayer.deploy(wallet.config, context)
+        expect(await isValidSignature(wallet.address, subDigest, signature, ganache.provider, context)).to.be.false
       })
     })
   })

--- a/packages/provider/tests/wallet.spec.ts
+++ b/packages/provider/tests/wallet.spec.ts
@@ -13,7 +13,7 @@ import { Signer as AbstractSigner } from 'ethers'
 
 import * as chaiAsPromised from 'chai-as-promised'
 import * as chai from 'chai'
-import { isValidSignature, isValidEthSignSignature, encodeMessageData, isValidWalletSignature, isValidArcadeumWalletSignature, isValidArcadeumFixedSignature } from '../src/utils'
+import { isValidSignature, isValidEthSignSignature, encodeMessageData, isValidWalletSignature, isValidArcadeumDeployedWalletSignature, isValidArcadeumUndeployedWalletSignature } from '../src/utils'
 
 const CallReceiverMockArtifact = require('arcadeum-wallet/build/contracts/CallReceiverMock.json')
 const HookCallerMockArtifact = require('arcadeum-wallet/build/contracts/HookCallerMock.json')
@@ -722,7 +722,7 @@ describe('Arcadeum wallet integration', function () {
       it('Should validate arcadeum wallet signature using direct method', async () => {
         const signature = await wallet.signMessage(message, 1)
         await relayer.deploy(wallet.config, context)
-        expect(await isValidArcadeumWalletSignature(wallet.address, digest, signature, ganache.provider)).to.be.true
+        expect(await isValidArcadeumDeployedWalletSignature(wallet.address, digest, signature, ganache.provider)).to.be.true
       })
       it('Should reject arcadeum wallet invalid signature', async () => {
         const wallet2 = await arcadeum.Wallet.singleOwner(context, new ethers.Wallet(ethers.utils.randomBytes(32)))
@@ -741,7 +741,7 @@ describe('Arcadeum wallet integration', function () {
       })
       it('Should validate arcadeum wallet signature using direct method', async () => {
         const signature = await wallet.signMessage(message, 1)
-        expect(await isValidArcadeumFixedSignature(wallet.address, digest, signature, context, ganache.provider)).to.be.true
+        expect(await isValidArcadeumUndeployedWalletSignature(wallet.address, digest, signature, context, ganache.provider)).to.be.true
       })
       it('Should reject arcadeum wallet invalid signature', async () => {
         const wallet2 = await arcadeum.Wallet.singleOwner(context, new ethers.Wallet(ethers.utils.randomBytes(32)))

--- a/packages/provider/tests/wallet.spec.ts
+++ b/packages/provider/tests/wallet.spec.ts
@@ -710,7 +710,7 @@ describe('Arcadeum wallet integration', function () {
         const signer1 = new ethers.Wallet(ethers.utils.randomBytes(32))
         const signer2 = new ethers.Wallet(ethers.utils.randomBytes(32))
         const signature = await signer1.signMessage(digest)
-        expect(await isValidSignature(signer2.address, digest, signature, ganache.provider, context)).to.be.false
+        expect(await isValidSignature(signer2.address, digest, signature)).to.be.undefined
       })
     })
     describe('deployed arcadeum wallet sign', async () => {

--- a/packages/provider/tests/wallet.unit.spec.ts
+++ b/packages/provider/tests/wallet.unit.spec.ts
@@ -55,11 +55,11 @@ describe('Arcadeum wallet', function() {
       const pk = ethers.utils.randomBytes(32)
       const wallet = await arcadeum.Wallet.singleOwner(context, pk)
 
-      const message = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hi! this is a test message'))
+      const message = ethers.utils.toUtf8Bytes('Hi! this is a test message')
       const chainId = 3
 
       const sig = await wallet.signMessage(message, chainId)
-      const digest = encodeMessageData(wallet.address, chainId, ethers.utils.hashMessage(ethers.utils.arrayify(message)))
+      const digest = encodeMessageData(wallet.address, chainId, ethers.utils.keccak256(message))
       const recovered = recoverConfig(digest, sig)
 
       expect(recovered.threshold).to.equal(1)
@@ -85,11 +85,11 @@ describe('Arcadeum wallet', function() {
         singer1
       )
 
-      const message = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hi! this is a test message'))
+      const message = ethers.utils.toUtf8Bytes('Hi! this is a test message')
       const chainId = 3
 
       const sig = await wallet.signMessage(message, chainId)
-      const digest = encodeMessageData(wallet.address, chainId, ethers.utils.hashMessage(ethers.utils.arrayify(message)))
+      const digest = encodeMessageData(wallet.address, chainId, ethers.utils.keccak256(message))
       const recovered = recoverConfig(digest, sig)
 
       expect(recovered.threshold).to.equal(3)


### PR DESCRIPTION
- Fixes double hashing during `Wallet.signMessage`
- Implements `isValidSignature` with compatibility for EIP712, EthSign, Wallet sign, Wallet sign (Arcadeum), Arcadeum static sign (counterfactual against create2)

Implements https://github.com/horizon-games/issue-tracker/issues/2700
Replaces https://github.com/arcadeum/arcadeum.js/pull/11