### PR TITLE
Implement updateConfig method

### DIFF
--- a/packages/provider/src/abi/mainModule.ts
+++ b/packages/provider/src/abi/mainModule.ts
@@ -58,12 +58,6 @@ export const abi = [
           }
         ],
         type: 'tuple[]'
-      },
-      {
-        type: 'uint256'
-      },
-      {
-        type: 'bytes'
       }
     ],
     outputs: [],

--- a/packages/provider/src/abi/mainModule.ts
+++ b/packages/provider/src/abi/mainModule.ts
@@ -14,6 +14,64 @@ export const abi = [
   },
   {
     type: 'function',
+    name: 'updateImplementation',
+    constant: false,
+    inputs: [
+      {
+        type: 'address'
+      }
+    ],
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    name: 'selfExecute',
+    constant: false,
+    inputs: [
+      {
+        components: [
+          {
+            type: 'bool',
+            name: 'delegateCall'
+          },
+          {
+            type: 'bool',
+            name: 'revertOnError'
+          },
+          {
+            type: 'uint256',
+            name: 'gasLimit'
+          },
+          {
+            type: 'address',
+            name: 'target'
+          },
+          {
+            type: 'uint256',
+            name: 'value'
+          },
+          {
+            type: 'bytes',
+            name: 'data'
+          }
+        ],
+        type: 'tuple[]'
+      },
+      {
+        type: 'uint256'
+      },
+      {
+        type: 'bytes'
+      }
+    ],
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
     name: 'execute',
     constant: false,
     inputs: [

--- a/packages/provider/src/abi/mainModuleUpgradable.ts
+++ b/packages/provider/src/abi/mainModuleUpgradable.ts
@@ -3,12 +3,12 @@ export const abi = [
     type: 'function',
     name: 'updateImageHash',
     constant: true,
-    inputs: [],
-    outputs: [
+    inputs: [
       {
         type: 'bytes32'
       }
     ],
+    outputs: [],
     payable: false,
     stateMutability: 'view'
   }

--- a/packages/provider/src/abi/mainModuleUpgradable.ts
+++ b/packages/provider/src/abi/mainModuleUpgradable.ts
@@ -1,0 +1,15 @@
+export const abi = [
+  {
+    type: 'function',
+    name: 'updateImageHash',
+    constant: true,
+    inputs: [],
+    outputs: [
+      {
+        type: 'bytes32'
+      }
+    ],
+    payable: false,
+    stateMutability: 'view'
+  }
+]

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -100,7 +100,8 @@ export interface ArcadeumWalletConfig {
 
 export interface ArcadeumContext {
   factory: string
-  mainModule: string
+  mainModule: string,
+  mainModuleUpgradable: string
 }
 
 export interface ArcadeumDecodedSignature {

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -91,6 +91,7 @@ export type OnNextCompleted = (err: Error | null, result: any, cb: Callback) => 
 export type NextCallback = (callback?: OnNextCompleted) => void
 
 export interface ArcadeumWalletConfig {
+  address?: string,
   threshold: number
   signers: {
     weight: number

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -102,7 +102,8 @@ export interface ArcadeumWalletConfig {
 export interface ArcadeumContext {
   factory: string
   mainModule: string,
-  mainModuleUpgradable: string
+  mainModuleUpgradable: string,
+  nonStrict?: boolean
 }
 
 export interface ArcadeumDecodedSignature {

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -34,6 +34,8 @@ export function sortConfig(config: ArcadeumWalletConfig): ArcadeumWalletConfig {
   return config
 }
 
+// isUsableConfig checks if a the sum of the owners in the configuration meets the necessary threshold to sign a transaction
+// a wallet that has a non-usable configuration is not able to perform any transactions, and can be considered as destroyed
 export function isUsableConfig(config: ArcadeumWalletConfig): boolean {
   const sum = config.signers.reduce((p, c) => ethers.utils.bigNumberify(c.weight).add(p), ethers.constants.Zero)
   return sum.gte(ethers.utils.bigNumberify(config.threshold))

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -16,8 +16,6 @@ import { TransactionRequest, Provider } from 'ethers/providers'
 import { abi as mainModuleAbi } from './abi/mainModule'
 import { abi as erc1271Abi, returns as erc1271returns } from './abi/erc1271'
 
-export const LIMIT_UINT_248 = ethers.constants.Two.pow(248)
-
 export function compareAddr(a: string, b: string): number {
   const bigA = ethers.utils.bigNumberify(a)
   const bigB = ethers.utils.bigNumberify(b)

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -48,6 +48,8 @@ export function imageHash(config: ArcadeumWalletConfig): string {
 }
 
 export function addressOf(config: ArcadeumWalletConfig, context: ArcadeumContext): string {
+  if (config.address) return config.address
+
   const salt = imageHash(config)
 
   const codeHash = ethers.utils.keccak256(

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -16,6 +16,8 @@ import { TransactionRequest, Provider } from 'ethers/providers'
 import { abi as mainModuleAbi } from './abi/mainModule'
 import { abi as erc1271Abi, returns as erc1271returns } from './abi/erc1271'
 
+export const LIMIT_UINT_248 = ethers.constants.Two.pow(248)
+
 export function compareAddr(a: string, b: string): number {
   const bigA = ethers.utils.bigNumberify(a)
   const bigB = ethers.utils.bigNumberify(b)

--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -34,6 +34,11 @@ export function sortConfig(config: ArcadeumWalletConfig): ArcadeumWalletConfig {
   return config
 }
 
+export function isUsableConfig(config: ArcadeumWalletConfig): boolean {
+  const sum = config.signers.reduce((p, c) => ethers.utils.bigNumberify(c.weight).add(p), ethers.constants.Zero)
+  return sum.gte(ethers.utils.bigNumberify(config.threshold))
+}
+
 export function imageHash(config: ArcadeumWalletConfig): string {
   let imageHash = ethers.utils.solidityPack(['uint256'], [config.threshold])
 

--- a/packages/provider/src/wallet.ts
+++ b/packages/provider/src/wallet.ts
@@ -12,7 +12,6 @@ import {
   hasArcadeumTransactions,
   toArcadeumTransactions,
   compareAddr,
-  LIMIT_UINT_248,
   imageHash
 } from './utils'
 import { BigNumberish, Arrayish, Interface } from 'ethers/utils'
@@ -93,21 +92,25 @@ export class Wallet extends AbstractSigner {
 
     const walletInterface = new Interface(mainModuleAbi)
 
+    // 131072 gas, enough for all calls
+    // and a power of two to keep the gas cost of data low
+    const gasLimit = ethers.constants.Two.pow(17)
+
     const preTransaction = isUpgradable ? [] : [{
       delegateCall: false,
       revertOnError: true,
-      gasLimit: LIMIT_UINT_248,
+      gasLimit: gasLimit,
       to: this.address,
       value: ethers.constants.Zero,
       data: walletInterface.functions.updateImplementation.encode(
         [this.context.mainModuleUpgradable]
       )
     }]
-    
+
     const transactions = [...preTransaction, {
       delegateCall: false,
       revertOnError: true,
-      gasLimit: LIMIT_UINT_248,
+      gasLimit: gasLimit,
       to: this.address,
       value: ethers.constants.Zero,
       data: new Interface(mainModuleUpgradableAbi).functions.updateImageHash.encode(
@@ -118,7 +121,7 @@ export class Wallet extends AbstractSigner {
     return [{
       delegateCall: false,
       revertOnError: false,
-      gasLimit: LIMIT_UINT_248,
+      gasLimit: gasLimit,
       to: this.address,
       value: ethers.constants.Zero,
       data: walletInterface.functions.selfExecute.encode(transactions)

--- a/packages/provider/tests/utils.unit.spec.ts
+++ b/packages/provider/tests/utils.unit.spec.ts
@@ -33,7 +33,8 @@ describe('Arcadeum utils', function () {
 
     const context = {
       factory: '0x7c2C195CD6D34B8F845992d380aADB2730bB9C6F',
-      mainModule: '0x8858eeB3DfffA017D4BCE9801D340D36Cf895CCf'
+      mainModule: '0x8858eeB3DfffA017D4BCE9801D340D36Cf895CCf',
+      mainModuleUpgradable: '0xC7cE8a07f69F226E52AEfF57085d8C915ff265f7'
     }
 
     const expected = '0xF0BA65550F2d1DCCf4B131B774844DC3d801D886'

--- a/packages/provider/tests/utils/arcadeum_config.ts
+++ b/packages/provider/tests/utils/arcadeum_config.ts
@@ -2,14 +2,16 @@ import { Provider } from 'ethers/providers'
 import { ethers } from 'ethers'
 
 import { MainModule } from 'arcadeum-wallet/typings/contracts/MainModule'
+import { MainModuleUpgradable } from 'arcadeum-wallet/typings/contracts/MainModuleUpgradable'
 import { Factory } from 'arcadeum-wallet/typings/contracts/Factory'
 
 const FactoryArtifact = require('arcadeum-wallet/build/contracts/Factory.json')
 const MainModuleArtifact = require('arcadeum-wallet/build/contracts/MainModule.json')
+const MainModuleUpgradableArtifact = require('arcadeum-wallet/build/contracts/MainModuleUpgradable.json')
 
 ethers.errors.setLogLevel('error')
 
-export async function deployArcadeum(provider: Provider): Promise<[Factory, MainModule]> {
+export async function deployArcadeum(provider: Provider): Promise<[Factory, MainModule, MainModuleUpgradable]> {
   const factory = ((await new ethers.ContractFactory(
     FactoryArtifact.abi,
     FactoryArtifact.bytecode,
@@ -22,5 +24,11 @@ export async function deployArcadeum(provider: Provider): Promise<[Factory, Main
     (provider as any).getSigner()
   ).deploy(factory.address)) as unknown) as MainModule
 
-  return [factory, mainModule]
+  const mainModuleUpgradable = ((await new ethers.ContractFactory(
+    MainModuleUpgradableArtifact.abi,
+    MainModuleUpgradableArtifact.bytecode,
+    (provider as any).getSigner()
+  ).deploy()) as unknown) as MainModuleUpgradable
+
+  return [factory, mainModule, mainModuleUpgradable]
 }

--- a/packages/provider/tests/utils/arcadeum_config.ts
+++ b/packages/provider/tests/utils/arcadeum_config.ts
@@ -5,9 +5,9 @@ import { MainModule } from 'arcadeum-wallet/typings/contracts/MainModule'
 import { MainModuleUpgradable } from 'arcadeum-wallet/typings/contracts/MainModuleUpgradable'
 import { Factory } from 'arcadeum-wallet/typings/contracts/Factory'
 
-const FactoryArtifact = require('arcadeum-wallet/build/contracts/Factory.json')
-const MainModuleArtifact = require('arcadeum-wallet/build/contracts/MainModule.json')
-const MainModuleUpgradableArtifact = require('arcadeum-wallet/build/contracts/MainModuleUpgradable.json')
+const FactoryArtifact = require('arcadeum-wallet/artifacts/Factory.json')
+const MainModuleArtifact = require('arcadeum-wallet/artifacts/MainModule.json')
+const MainModuleUpgradableArtifact = require('arcadeum-wallet/artifacts/MainModuleUpgradable.json')
 
 ethers.errors.setLogLevel('error')
 

--- a/packages/provider/tests/wallet.spec.ts
+++ b/packages/provider/tests/wallet.spec.ts
@@ -926,5 +926,47 @@ describe('Arcadeum wallet integration', function () {
         expect(tx).to.be.rejected
       })
     })
+    it('Should reject a non-usable configuration', async () => {
+      const s1 = new ethers.Wallet(ethers.utils.randomBytes(32))
+      const s2 = new ethers.Wallet(ethers.utils.randomBytes(32))
+
+      const newConfig = {
+        threshold: 3,
+        signers: [
+          {
+            address: s1.address,
+            weight: 1
+          },
+          {
+            address: s2.address,
+            weight: 1
+          }
+        ]
+      }
+
+      const prom = wallet.buildUpdateConfig(newConfig)
+      await expect(prom).to.be.rejected
+    })
+    it('Should accept a non-usable configuration in non-strict mode', async () => {
+      const s1 = new ethers.Wallet(ethers.utils.randomBytes(32))
+      const s2 = new ethers.Wallet(ethers.utils.randomBytes(32))
+
+      const newConfig = {
+        threshold: 3,
+        signers: [
+          {
+            address: s1.address,
+            weight: 1
+          },
+          {
+            address: s2.address,
+            weight: 1
+          }
+        ]
+      }
+
+      const prom = wallet.buildUpdateConfig(newConfig, false)
+      await expect(prom).to.be.not.rejected
+    })
   })
 })

--- a/packages/provider/tests/wallet.spec.ts
+++ b/packages/provider/tests/wallet.spec.ts
@@ -948,6 +948,11 @@ describe('Arcadeum wallet integration', function () {
       await expect(prom).to.be.rejected
     })
     it('Should accept a non-usable configuration in non-strict mode', async () => {
+      const wallet = (await arcadeum.Wallet.singleOwner(
+        { nonStrict: true, ...context},
+        new ethers.Wallet(ethers.utils.randomBytes(32))
+      )).connect(ganache.serverUri, relayer)
+
       const s1 = new ethers.Wallet(ethers.utils.randomBytes(32))
       const s2 = new ethers.Wallet(ethers.utils.randomBytes(32))
 
@@ -965,7 +970,7 @@ describe('Arcadeum wallet integration', function () {
         ]
       }
 
-      const prom = wallet.buildUpdateConfig(newConfig, false)
+      const prom = wallet.buildUpdateConfig(newConfig)
       await expect(prom).to.be.not.rejected
     })
   })

--- a/packages/provider/tests/wallet.spec.ts
+++ b/packages/provider/tests/wallet.spec.ts
@@ -49,12 +49,13 @@ describe('Arcadeum wallet integration', function () {
     ganache.signer = ganache.provider.getSigner()
 
     // Deploy Arcadeum env
-    const [factory, mainModule] = await deployArcadeum(ganache.provider)
+    const [factory, mainModule, mainModuleUpgradable] = await deployArcadeum(ganache.provider)
 
     // Create fixed context obj
     context = {
       factory: factory.address,
-      mainModule: mainModule.address
+      mainModule: mainModule.address,
+      mainModuleUpgradable: mainModuleUpgradable.address
     }
 
     // Deploy call receiver mock

--- a/packages/provider/tests/wallet.spec.ts
+++ b/packages/provider/tests/wallet.spec.ts
@@ -13,10 +13,10 @@ import { Signer as AbstractSigner } from 'ethers'
 
 import * as chaiAsPromised from 'chai-as-promised'
 import * as chai from 'chai'
-import { isValidSignature, isValidEthSignSignature, encodeMessageData, isValidWalletSignature, isValidArcadeumDeployedWalletSignature, isValidArcadeumUndeployedWalletSignature } from '../src/utils'
+import { isValidSignature, isValidEthSignSignature, encodeMessageData, isValidWalletSignature, isValidArcadeumDeployedWalletSignature, isValidArcadeumUndeployedWalletSignature, addressOf } from '../src/utils'
 
-const CallReceiverMockArtifact = require('arcadeum-wallet/build/contracts/CallReceiverMock.json')
-const HookCallerMockArtifact = require('arcadeum-wallet/build/contracts/HookCallerMock.json')
+const CallReceiverMockArtifact = require('arcadeum-wallet/artifacts/CallReceiverMock.json')
+const HookCallerMockArtifact = require('arcadeum-wallet/artifacts/HookCallerMock.json')
 
 const Web3 = require('web3')
 const { expect } = chai.use(chaiAsPromised)
@@ -772,6 +772,158 @@ describe('Arcadeum wallet integration', function () {
         const subDigest = ethers.utils.arrayify(ethers.utils.keccak256(encodeMessageData(wallet.address, 1, digest)))
         await relayer.deploy(wallet.config, context)
         expect(await isValidSignature(wallet.address, subDigest, signature, ganache.provider, context)).to.be.false
+      })
+    })
+  })
+  describe('Update wallet configuration', () => {
+    let transaction: arcadeum.Transactionish
+    beforeEach(async () => {
+      transaction = {
+        from: wallet.address,
+        gasPrice: '20000000000',
+        to: callReceiver.address,
+        value: 0,
+        data: callReceiver.interface.functions.testCall.encode([123, '0x445566'])
+      }
+    })
+    it('Should migrate and update to a new single owner configuration', async () => {
+      const s1 = new ethers.Wallet(ethers.utils.randomBytes(32))
+
+      const newConfig = {
+        threshold: 1,
+        signers: [
+          {
+            address: s1.address,
+            weight: 1
+          }
+        ]
+      }
+
+      const [config, tx] = await wallet.updateConfig(newConfig)
+      await tx.wait()
+
+      const updatedWallet = new arcadeum.Wallet(config, context, s1).connect(ganache.serverUri, relayer)
+
+      expect(ethers.utils.getAddress(await ganache.provider.getStorageAt(wallet.address, wallet.address)))
+        .to.equal(ethers.utils.getAddress(context.mainModuleUpgradable))
+
+      expect(updatedWallet.address).to.be.equal(wallet.address)
+      expect(updatedWallet.address).to.not.be.equal(addressOf(newConfig, context))
+
+      await updatedWallet.sendTransaction(transaction)
+    })
+    it('Should migrate and update to a new multiple owner configuration', async () => {
+      const s1 = new ethers.Wallet(ethers.utils.randomBytes(32))
+      const s2 = new ethers.Wallet(ethers.utils.randomBytes(32))
+
+      const newConfig = {
+        threshold: 2,
+        signers: [
+          {
+            address: s1.address,
+            weight: 1
+          },
+          {
+            address: s2.address,
+            weight: 1
+          }
+        ]
+      }
+
+      const [config, tx] = await wallet.updateConfig(newConfig)
+      const txr = await tx.wait()
+
+      const updatedWallet = new arcadeum.Wallet(config, context, s1, s2).connect(ganache.serverUri, relayer)
+
+      expect(ethers.utils.getAddress(await ganache.provider.getStorageAt(wallet.address, wallet.address)))
+        .to.equal(ethers.utils.getAddress(context.mainModuleUpgradable))
+
+      expect(updatedWallet.address).to.be.equal(wallet.address)
+      expect(updatedWallet.address).to.not.be.equal(addressOf(newConfig, context))
+
+      await updatedWallet.sendTransaction(transaction)
+    })
+    describe('after migrating and updating', () => {
+      let wallet2: arcadeum.Wallet
+
+      beforeEach(async () => {
+        const s1 = new ethers.Wallet(ethers.utils.randomBytes(32))
+
+        const newConfig = {
+          threshold: 1,
+          signers: [
+            {
+              address: s1.address,
+              weight: 1
+            }
+          ]
+        }
+  
+        const [config, tx] = await wallet.updateConfig(newConfig)
+        await tx.wait()
+
+        wallet2 = new arcadeum.Wallet(config, context, s1).connect(ganache.serverUri, relayer)
+      })
+      it('Should update to a new single owner configuration', async () => {
+        const s1 = new ethers.Wallet(ethers.utils.randomBytes(32))
+
+        const newConfig = {
+          threshold: 1,
+          signers: [
+            {
+              address: s1.address,
+              weight: 1
+            }
+          ]
+        }
+  
+        const [config, tx] = await wallet2.updateConfig(newConfig)
+        await tx.wait()
+  
+        const updatedWallet = new arcadeum.Wallet(config, context, s1).connect(ganache.serverUri, relayer)
+  
+        expect(ethers.utils.getAddress(await ganache.provider.getStorageAt(wallet2.address, wallet2.address)))
+          .to.equal(ethers.utils.getAddress(context.mainModuleUpgradable))
+  
+        expect(updatedWallet.address).to.be.equal(wallet2.address)
+        expect(updatedWallet.address).to.not.be.equal(addressOf(newConfig, context))
+  
+        await updatedWallet.sendTransaction(transaction)
+      })
+      it('Should update to a new multiple owner configuration', async () => {
+        const s1 = new ethers.Wallet(ethers.utils.randomBytes(32))
+        const s2 = new ethers.Wallet(ethers.utils.randomBytes(32))
+  
+        const newConfig = {
+          threshold: 2,
+          signers: [
+            {
+              address: s1.address,
+              weight: 1
+            },
+            {
+              address: s2.address,
+              weight: 1
+            }
+          ]
+        }
+  
+        const [config, tx] = await wallet2.updateConfig(newConfig)
+        await tx.wait()
+  
+        const updatedWallet = new arcadeum.Wallet(config, context, s1, s2).connect(ganache.serverUri, relayer)
+  
+        expect(ethers.utils.getAddress(await ganache.provider.getStorageAt(wallet2.address, wallet2.address)))
+          .to.equal(ethers.utils.getAddress(context.mainModuleUpgradable))
+  
+        expect(updatedWallet.address).to.be.equal(wallet2.address)
+        expect(updatedWallet.address).to.not.be.equal(addressOf(newConfig, context))
+  
+        await updatedWallet.sendTransaction(transaction)
+      })
+      it('Should reject transaction of previous owner', async () => {
+        const tx = wallet.sendTransaction(transaction)
+        expect(tx).to.be.rejected
       })
     })
   })

--- a/packages/provider/tests/wallet.unit.spec.ts
+++ b/packages/provider/tests/wallet.unit.spec.ts
@@ -8,7 +8,8 @@ import { encodeMessageData, recoverConfig } from '../src/utils';
 describe('Arcadeum wallet units', function() {
   const context = {
     factory: '0x7c2C195CD6D34B8F845992d380aADB2730bB9C6F',
-    mainModule: '0x8858eeB3DfffA017D4BCE9801D340D36Cf895CCf'
+    mainModule: '0x8858eeB3DfffA017D4BCE9801D340D36Cf895CCf',
+    mainModuleUpgradable: '0xC7cE8a07f69F226E52AEfF57085d8C915ff265f7'
   }
 
   describe('wallet creation', () => {
@@ -41,7 +42,8 @@ describe('Arcadeum wallet units', function() {
         }],
         context: {
           factory: '0x7c2C195CD6D34B8F845992d380aADB2730bB9C6F',
-          mainModule: '0x8858eeB3DfffA017D4BCE9801D340D36Cf895CCf'
+          mainModule: '0x8858eeB3DfffA017D4BCE9801D340D36Cf895CCf',
+          mainModuleUpgradable: '0xC7cE8a07f69F226E52AEfF57085d8C915ff265f7'
         }
       }
 

--- a/packages/provider/tests/wallet.unit.spec.ts
+++ b/packages/provider/tests/wallet.unit.spec.ts
@@ -28,6 +28,40 @@ describe('Arcadeum wallet units', function() {
       const expected = '0xF0BA65550F2d1DCCf4B131B774844DC3d801D886'
       expect(wallet.address).to.be.equal(expected)
     })
+    it('Should reject non-usable config', () => {
+      const config = {
+        threshold: 4,
+        signers: [
+          {
+            address: '0x173C645E3a784612bC3132cA8ae47AFE4Ef405c4',
+            weight: 1
+          },
+          {
+            address: '0xEc5526D3C399f9810a70D44c90a680Dce93b7bEc',
+            weight: 1
+          }
+        ]
+      }
+
+      expect(() => new arcadeum.Wallet(config, context)).to.throw(Error)
+    })
+    it('Should accept non-usable config on non-strict mode', () => {
+      const config = {
+        threshold: 4,
+        signers: [
+          {
+            address: '0x173C645E3a784612bC3132cA8ae47AFE4Ef405c4',
+            weight: 1
+          },
+          {
+            address: '0xEc5526D3C399f9810a70D44c90a680Dce93b7bEc',
+            weight: 1
+          }
+        ]
+      }
+
+      expect(() => new arcadeum.Wallet(config, { nonStrict: true, ...context })).to.not.throw(Error)
+    })
   })
   describe('signing', () => {
     it('Should sign a message', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,7 +1846,7 @@ aproba@^2.0.0:
 
 "arcadeum-wallet@https://github.com/arcadeum/wallet-contracts.git":
   version "0.1.0"
-  resolved "https://github.com/arcadeum/wallet-contracts.git#739972be1c20c563776d256209c54308bf9d43ec"
+  resolved "https://github.com/arcadeum/wallet-contracts.git#47033ddab73dc89b9ebca3e930e979553b7a65de"
 
 archy@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Add `updateConfig` method to wallet
-> Migrate wallet from `fixed` to `upgradable` if required
-> Use bundle atomicity for secure migration
-> Detect and reject non-usable configurations
- Add fixed `address` as an optional parameter in configuration
- Add strict mode on context, used to determined if non-usable configurations should be rejected
-> Detect and reject non-usable configurations during wallet creation
- Upgrade contracts

note: non-usable configurations are valid, but are not usable because the sum of all signers doesn't reaches the threshold.