### PR TITLE
Estimate gasLimits locally

### DIFF
--- a/packages/provider/src/relayer/index.ts
+++ b/packages/provider/src/relayer/index.ts
@@ -2,6 +2,12 @@ import { ArcadeumTransaction, ArcadeumContext, ArcadeumWalletConfig } from '../t
 import { TransactionResponse, BlockTag } from 'ethers/providers'
 
 export interface IRelayer {
+  estimateGasLimits(
+    config: ArcadeumWalletConfig,
+    context: ArcadeumContext,
+    ...transactions: ArcadeumTransaction[]
+  ): Promise<ArcadeumTransaction[]>
+
   getNonce(
     config: ArcadeumWalletConfig,
     context: ArcadeumContext,

--- a/packages/provider/src/relayer/local-relayer.ts
+++ b/packages/provider/src/relayer/local-relayer.ts
@@ -9,6 +9,8 @@ import { addressOf } from '../utils'
 
 import { IRelayer } from '.'
 
+const DEFAULT_FEE = ethers.utils.bigNumberify(800000)
+
 export class LocalRelayer extends BaseRelayer implements IRelayer {
   private readonly signer: Signer
 
@@ -21,6 +23,40 @@ export class LocalRelayer extends BaseRelayer implements IRelayer {
     return this.signer.sendTransaction(
       this.prepareWalletDeploy(config, context)
     )
+  }
+
+  async estimateGasLimits(
+    config: ArcadeumWalletConfig,
+    context: ArcadeumContext,
+    ...transactions: ArcadeumTransaction[]
+  ): Promise<ArcadeumTransaction[]> {
+    const walletAddr = addressOf(config, context)
+
+    const gasCosts = await Promise.all(transactions.map(async (t) => {
+      // Fee can't be estimated locally for delegateCalls
+      if (t.delegateCall) {
+        return DEFAULT_FEE
+      }
+
+      // Fee can't be estimated for self-called if wallet hasn't been deployed
+      if (t.to === walletAddr && !(await this.isWalletDeployed(walletAddr))) {
+        return DEFAULT_FEE
+      }
+
+      // TODO: If the wallet address has been deployed, gas limits can be
+      // estimated with more accuracy by using self-calls with the batch transactions one by one
+      return this.signer.provider.estimateGas({
+        from: walletAddr,
+        to: t.to,
+        data: t.data,
+        value: t.value
+      })
+    }))
+
+    return transactions.map((t, i) => {
+      t.gasLimit = gasCosts[i]
+      return t
+    })
   }
 
   async getNonce(

--- a/packages/provider/src/relayer/local-relayer.ts
+++ b/packages/provider/src/relayer/local-relayer.ts
@@ -9,7 +9,7 @@ import { addressOf } from '../utils'
 
 import { IRelayer } from '.'
 
-const DEFAULT_FEE = ethers.utils.bigNumberify(800000)
+const DEFAULT_GAS_LIMIT = ethers.utils.bigNumberify(800000)
 
 export class LocalRelayer extends BaseRelayer implements IRelayer {
   private readonly signer: Signer
@@ -35,12 +35,12 @@ export class LocalRelayer extends BaseRelayer implements IRelayer {
     const gasCosts = await Promise.all(transactions.map(async (t) => {
       // Fee can't be estimated locally for delegateCalls
       if (t.delegateCall) {
-        return DEFAULT_FEE
+        return DEFAULT_GAS_LIMIT
       }
 
       // Fee can't be estimated for self-called if wallet hasn't been deployed
       if (t.to === walletAddr && !(await this.isWalletDeployed(walletAddr))) {
-        return DEFAULT_FEE
+        return DEFAULT_GAS_LIMIT
       }
 
       // TODO: If the wallet address has been deployed, gas limits can be

--- a/packages/provider/src/relayer/rpc-relayer.ts
+++ b/packages/provider/src/relayer/rpc-relayer.ts
@@ -60,6 +60,14 @@ export class RpcRelayer extends BaseRelayer implements IRelayer {
     return result
   }
 
+  async estimateGasLimits(
+    config: ArcadeumWalletConfig,
+    context: ArcadeumContext,
+    ...transactions: ArcadeumTransaction[]
+  ): Promise<ArcadeumTransaction[]> {
+    throw new Error("Not implemented")
+  }
+
   async getNonce(
     config: ArcadeumWalletConfig,
     context: ArcadeumContext,

--- a/packages/provider/src/wallet.ts
+++ b/packages/provider/src/wallet.ts
@@ -181,6 +181,12 @@ export class Wallet extends AbstractSigner {
       arctx = await toArcadeumTransactions(this, [transaction])
     }
 
+    // If all transactions have 0 gasLimit
+    // estimate gasLimits for each transaction
+    if (!arctx.find((a) => !a.revertOnError && !ethers.utils.bigNumberify(a.gasLimit).eq(ethers.constants.Zero))) {
+      arctx = await this.relayer.estimateGasLimits(this.config, this.context, ...arctx)
+    }
+
     const providedNonce = readArcadeumNonce(...arctx)
     const nonce = providedNonce ? providedNonce : await this.getNonce()
     arctx = appendNonce(arctx, nonce)

--- a/packages/provider/tests/wallet.spec.ts
+++ b/packages/provider/tests/wallet.spec.ts
@@ -588,6 +588,8 @@ describe('Arcadeum wallet integration', function () {
 
     describe('estimate gas', async () => {
       it('Should estimate gas for a single meta-tx', async () => {
+        await callReceiver.testCall(0, '0x')
+
         const transaction = {
           from: wallet.address,
           gasPrice: '20000000000',
@@ -603,6 +605,8 @@ describe('Arcadeum wallet integration', function () {
         expect((<any>estimated[0].gasLimit).toNumber()).to.be.below(100000)
       })
       it('Should estimate gas for a single big meta-tx', async () => {
+        await callReceiver.testCall(0, '0x')
+
         const data = ethers.utils.randomBytes(512)
         const transaction = {
           from: wallet.address,
@@ -619,6 +623,8 @@ describe('Arcadeum wallet integration', function () {
         expect((<any>estimated[0].gasLimit).toNumber()).to.be.below(400000)
       })
       it('Should estimate gas for a batch of meta-txs', async () => {
+        await callReceiver.testCall(0, '0x')
+
         const data = ethers.utils.randomBytes(512)
         const transactions = [{
           from: wallet.address,


### PR DESCRIPTION
- Estimate gas limit using local-relayer
- When gas can't be estimated (self-calls, delegate-calls, etc) use default gasLimit
- Auto-estimate gas limit if all transactions have gasLimit 0 and revertOnError false