### PR TITLE
Expose batch transactions on window provider

### DIFF
--- a/packages/provider/src/context.ts
+++ b/packages/provider/src/context.ts
@@ -4,7 +4,8 @@ export const WalletContext: ArcadeumContext = {
   factory: '0x52f0F4258c69415567b21dfF085C3fd5505D5155',
   mainModule: '0x57bA6Eb1ed6821Db7bC26C6714f093E2BCbea40F',
   mainModuleUpgradable: '0xF52136A04057d889CeBf9bCc2F3142965AeABc54',
-  guestModule: '0xe076ad01F1eb18A8eF20bB64003DA4810a429a32'
+  guestModule: '0xe076ad01F1eb18A8eF20bB64003DA4810a429a32',
+  requireUtils: '0xd46566c23ae549fc14abfcfcbc130e3ea7e63f82'
 }
 
 export const ethereumNetworks: {[key: string]: NetworkConfig} = {

--- a/packages/provider/src/providers/arcadeum-web3-provider.ts
+++ b/packages/provider/src/providers/arcadeum-web3-provider.ts
@@ -3,9 +3,8 @@ import { Networkish, BigNumberish, Interface } from "ethers/utils"
 import { toArcadeumTransactions, makeExpirable, makeAfterNonce, arcadeumTxAbiEncode } from "../utils"
 import { NonceDependency, ArcadeumContext } from "../types"
 import { abi as mainModuleAbi } from '../abi/mainModule'
-import { ethers, Signer } from "ethers"
 
-export class SequenceWeb3Provider extends Web3Provider {
+export class ArcadeumWeb3Provider extends Web3Provider {
     private context: ArcadeumContext
 
     constructor(
@@ -17,12 +16,12 @@ export class SequenceWeb3Provider extends Web3Provider {
         this.context = context
     }
 
-    getSequenceSigner(): SequenceSigner {
-        return new SequenceSigner(this.context, this.getSigner())
+    getArcadeumSigner(): ArcadeumSigner {
+        return new ArcadeumSigner(this.context, this.getSigner())
     }
 }
 
-export class SequenceSigner {
+export class ArcadeumSigner {
     private context: ArcadeumContext
     private signer: JsonRpcSigner
 

--- a/packages/provider/src/providers/sequence-web3-provider.ts
+++ b/packages/provider/src/providers/sequence-web3-provider.ts
@@ -1,0 +1,61 @@
+import { Web3Provider, AsyncSendable, TransactionRequest, TransactionResponse, JsonRpcSigner } from "ethers/providers"
+import { Networkish, BigNumberish, Interface } from "ethers/utils"
+import { toArcadeumTransactions, makeExpirable, makeAfterNonce, arcadeumTxAbiEncode } from "../utils"
+import { NonceDependency, ArcadeumContext } from "../types"
+import { abi as mainModuleAbi } from '../abi/mainModule'
+import { ethers, Signer } from "ethers"
+
+export class SequenceWeb3Provider extends Web3Provider {
+    private context: ArcadeumContext
+
+    constructor(
+        context: ArcadeumContext,
+        web3Provider: AsyncSendable,
+        network?: Networkish
+    ) {
+        super(web3Provider, network)
+        this.context = context
+    }
+
+    getSequenceSigner(): SequenceSigner {
+        return new SequenceSigner(this.context, this.getSigner())
+    }
+}
+
+export class SequenceSigner {
+    private context: ArcadeumContext
+    private signer: JsonRpcSigner
+
+    constructor(
+        context: ArcadeumContext,
+        signer: JsonRpcSigner
+    ) {
+        this.context = context
+        this.signer = signer
+    }
+
+    async sendTransactionBatch(
+        transactions: TransactionRequest[],
+        expiration?: BigNumberish,
+        dependencies?: NonceDependency[]
+    ): Promise<TransactionResponse> {
+        const address = await this.signer.getAddress()
+
+        let arctxs = await toArcadeumTransactions(address, transactions, false)
+
+        if (expiration) {
+            arctxs = makeExpirable(this.context, arctxs, expiration)
+        }
+
+        if (dependencies && dependencies.length > 0) {
+            arctxs = dependencies.reduce((p, d) => makeAfterNonce(this.context, p, d), arctxs)
+        }
+
+        const walletInterface = new Interface(mainModuleAbi)
+
+        return this.signer.sendTransaction({
+            to: address,
+            data: walletInterface.functions.selfExecute.encode([arcadeumTxAbiEncode(arctxs)])
+        })
+    }
+}

--- a/packages/provider/src/providers/wallet-provider.ts
+++ b/packages/provider/src/providers/wallet-provider.ts
@@ -4,7 +4,7 @@ import { ExternalWindowProvider } from './external-window-provider'
 import { ProviderEngine, loggingProviderMiddleware, allowProviderMiddleware, CachedProvider, PublicProvider, JsonRpcMiddleware } from './provider-engine'
 import { WalletContext } from '../context'
 import { SidechainProvider } from './sidechain-provider'
-import { SequenceWeb3Provider } from './sequence-web3-provider'
+import { ArcadeumWeb3Provider } from './arcadeum-web3-provider'
 
 export interface IWalletProvider {
   login(): Promise<boolean>
@@ -55,14 +55,14 @@ export class WalletProvider implements IWalletProvider {
 
   private session: WalletSession | null
 
-  private provider: SequenceWeb3Provider
+  private provider: ArcadeumWeb3Provider
   private providerEngine?: ProviderEngine
   private cachedProvider?: CachedProvider
   private publicProvider?: PublicProvider
   private externalWindowProvider?: ExternalWindowProvider
   private allowProvider?: JsonRpcMiddleware
 
-  private sidechainProviders: { [id: number] : SequenceWeb3Provider }
+  private sidechainProviders: { [id: number] : ArcadeumWeb3Provider }
 
   constructor(config?: WalletProviderConfig) {
     this.config = config
@@ -105,7 +105,7 @@ export class WalletProvider implements IWalletProvider {
         ])
 
         // this.provider = this.providerEngine.createJsonRpcProvider()
-        this.provider = new SequenceWeb3Provider(
+        this.provider = new ArcadeumWeb3Provider(
           this.config.walletContext,
           this.providerEngine,
           'unspecified'
@@ -241,7 +241,7 @@ export class WalletProvider implements IWalletProvider {
     return this.sidechainProviders[chainId]
   }
 
-  getSidechainProviders(): { [id: number] : SequenceWeb3Provider } {
+  getSidechainProviders(): { [id: number] : ArcadeumWeb3Provider } {
     return this.sidechainProviders
   }
 
@@ -325,7 +325,7 @@ export class WalletProvider implements IWalletProvider {
     // TODO: with ethers v5, we can set network to 'any', then set network = null
     // anytime the network changes, and call detectNetwork(). We can reuse
     // that object instance instead of creating a new one as below.
-    this.provider = new SequenceWeb3Provider(
+    this.provider = new ArcadeumWeb3Provider(
       this.config.walletContext,
       this.providerEngine,
       network.name
@@ -366,13 +366,13 @@ export class WalletProvider implements IWalletProvider {
         publicProvider
       ])
 
-      providers[network.chainId] = new SequenceWeb3Provider(
+      providers[network.chainId] = new ArcadeumWeb3Provider(
         this.config.walletContext,
         providerEngine,
         network
       )
       return providers
-    }, {} as {[id: number]: SequenceWeb3Provider})
+    }, {} as {[id: number]: ArcadeumWeb3Provider})
   }
 }
 

--- a/packages/provider/src/providers/wallet-provider.ts
+++ b/packages/provider/src/providers/wallet-provider.ts
@@ -1,9 +1,10 @@
-import { JsonRpcProvider, JsonRpcSigner, AsyncSendable, Web3Provider } from 'ethers/providers'
+import { JsonRpcProvider, JsonRpcSigner, AsyncSendable } from 'ethers/providers'
 import { ArcadeumWalletConfig, ArcadeumContext, NetworkConfig } from '../types'
 import { ExternalWindowProvider } from './external-window-provider'
 import { ProviderEngine, loggingProviderMiddleware, allowProviderMiddleware, CachedProvider, PublicProvider, JsonRpcMiddleware } from './provider-engine'
 import { WalletContext } from '../context'
 import { SidechainProvider } from './sidechain-provider'
+import { SequenceWeb3Provider } from './sequence-web3-provider'
 
 export interface IWalletProvider {
   login(): Promise<boolean>
@@ -54,14 +55,14 @@ export class WalletProvider implements IWalletProvider {
 
   private session: WalletSession | null
 
-  private provider: JsonRpcProvider
+  private provider: SequenceWeb3Provider
   private providerEngine?: ProviderEngine
   private cachedProvider?: CachedProvider
   private publicProvider?: PublicProvider
   private externalWindowProvider?: ExternalWindowProvider
   private allowProvider?: JsonRpcMiddleware
 
-  private sidechainProviders: { [id: number] : Web3Provider }
+  private sidechainProviders: { [id: number] : SequenceWeb3Provider }
 
   constructor(config?: WalletProviderConfig) {
     this.config = config
@@ -104,7 +105,11 @@ export class WalletProvider implements IWalletProvider {
         ])
 
         // this.provider = this.providerEngine.createJsonRpcProvider()
-        this.provider = new Web3Provider(this.providerEngine, 'unspecified')
+        this.provider = new SequenceWeb3Provider(
+          this.config.walletContext,
+          this.providerEngine,
+          'unspecified'
+        )
 
         this.externalWindowProvider.on('network', network => {
           this.useNetwork(network)
@@ -236,7 +241,7 @@ export class WalletProvider implements IWalletProvider {
     return this.sidechainProviders[chainId]
   }
 
-  getSidechainProviders(): { [id: number] : Web3Provider } {
+  getSidechainProviders(): { [id: number] : SequenceWeb3Provider } {
     return this.sidechainProviders
   }
 
@@ -320,7 +325,11 @@ export class WalletProvider implements IWalletProvider {
     // TODO: with ethers v5, we can set network to 'any', then set network = null
     // anytime the network changes, and call detectNetwork(). We can reuse
     // that object instance instead of creating a new one as below.
-    this.provider = new Web3Provider(this.providerEngine, network.name)
+    this.provider = new SequenceWeb3Provider(
+      this.config.walletContext,
+      this.providerEngine,
+      network.name
+    )
 
     // ..
     this.publicProvider.setRpcUrl(network.rpcUrl)
@@ -357,9 +366,13 @@ export class WalletProvider implements IWalletProvider {
         publicProvider
       ])
 
-      providers[network.chainId] = new Web3Provider(providerEngine, network)
+      providers[network.chainId] = new SequenceWeb3Provider(
+        this.config.walletContext,
+        providerEngine,
+        network
+      )
       return providers
-    }, {} as {[id: number]: Web3Provider})
+    }, {} as {[id: number]: SequenceWeb3Provider})
   }
 }
 


### PR DESCRIPTION
Add `getSequenceSigner` to injected provider.
Sequence signer enables batch expirable transactions using `sendTransactionBatch`