### PR TITLE
authChain sign methods

### DIFF
--- a/packages/provider/src/multi-wallet.ts
+++ b/packages/provider/src/multi-wallet.ts
@@ -106,7 +106,7 @@ export class MultiWallet extends AbstractSigner {
     return this.signMessage(message, this.authWallet(), onlyFullSign)
   }
 
-  async signMessage(message: Arrayish, target?: Wallet | NetworkConfig, onlyFullSign: boolean = true): Promise<string> {
+  async signMessage(message: Arrayish, target?: Wallet | NetworkConfig | BigNumberish, onlyFullSign: boolean = true): Promise<string> {
     const wallet = (() => {
       if (!target) return this.mainWallet()
       if ((<Wallet>target).address) {

--- a/packages/provider/src/multi-wallet.ts
+++ b/packages/provider/src/multi-wallet.ts
@@ -280,7 +280,7 @@ export class MultiWallet extends AbstractSigner {
     return found ? found : this._wallets[0].wallet
   }
 
-  static isMultiWallet(signer: AbstractSigner): boolean {
+  static isMultiWallet(signer: AbstractSigner): signer is MultiWallet {
     return (<MultiWallet>signer).updateConfig !== undefined
   }
 }

--- a/packages/provider/src/providers/wallet-provider.ts
+++ b/packages/provider/src/providers/wallet-provider.ts
@@ -72,6 +72,7 @@ export class WalletProvider implements IWalletProvider {
   private externalWindowProvider?: ExternalWindowProvider
   private allowProvider?: JsonRpcMiddleware
 
+  private networks: NetworkConfig[]
   private sidechainProviders: { [id: number] : ArcadeumWeb3Provider }
 
   constructor(config?: WalletProviderConfig) {
@@ -260,6 +261,16 @@ export class WalletProvider implements IWalletProvider {
     return this.provider
   }
 
+  getAuthProvider(): JsonRpcProvider {
+    const provider = this.sidechainProviders[this.getAuthNetwork().chainId]
+    return provider ? provider : this.getProvider()
+  }
+
+  getAuthNetwork(): NetworkConfig {
+    const net = this.networks.find((n) => n.isAuth)
+    return net ? net : this.session.network
+  }
+
   getSidechainProvider(chainId: number): JsonRpcProvider | undefined {
     return this.sidechainProviders[chainId]
   }
@@ -401,6 +412,9 @@ export class WalletProvider implements IWalletProvider {
       )
       return providers
     }, {} as {[id: number]: ArcadeumWeb3Provider})
+
+    // Save raw networks
+    this.networks = networks
   }
 }
 


### PR DESCRIPTION
- Add `signAuthMessage` method to MultiWallet
- Accept custom network on `signMessage`
- Add `isMultiWallet` method
- Add `getAuthProvider` to wallet provider
- Add `getAuthNetwork` to wallet provider