### PR TITLE
Fix detect estimate gas limit

### DIFF
--- a/packages/provider/src/utils.ts
+++ b/packages/provider/src/utils.ts
@@ -460,12 +460,12 @@ export function readArcadeumNonce(...txs: ArcadeumTransaction[]): BigNumberish {
 
 export function arcadeumTxAbiEncode(txs: ArcadeumTransaction[]): ArcadeumTransactionEncoded[] {
   return txs.map(t => ({
-    delegateCall: t.delegateCall,
-    revertOnError: t.revertOnError,
-    gasLimit: t.gasLimit,
+    delegateCall: t.delegateCall === true,
+    revertOnError: t.revertOnError === true,
+    gasLimit: t.gasLimit !== undefined ? t.gasLimit : ethers.constants.Zero,
     target: t.to,
-    value: t.value,
-    data: t.data
+    value: t.value !== undefined ? t.value : ethers.constants.Zero,
+    data: t.data !== undefined ? t.data : []
   }))
 }
 

--- a/packages/provider/src/wallet.ts
+++ b/packages/provider/src/wallet.ts
@@ -285,9 +285,9 @@ export class Wallet extends AbstractSigner {
       )
     }
 
-    // If all transactions have 0 gasLimit
-    // estimate gasLimits for each transaction
-    if (!arctx.find((a) => !a.revertOnError && !ethers.BigNumber.from(a.gasLimit).eq(ethers.constants.Zero))) {
+    // If a transaction has 0 gasLimit and not revertOnError
+    // compute all new gas limits
+    if (arctx.find((a) => !a.revertOnError && ethers.BigNumber.from(a.gasLimit).eq(ethers.constants.Zero))) {
       arctx = await this.relayer.estimateGasLimits(this.config, this.context, ...arctx)
     }
 


### PR DESCRIPTION
- Estimate gas limit for meta-tx automatically only if one of the entries of the batch has `revertOnError: false && gasLimit == 0`.
- Define explicit default values on `arcadeumTxAbiEncode`