### PR TITLE
Common interface for Wallet and MultiWallet

### DIFF
--- a/packages/network/src/config.ts
+++ b/packages/network/src/config.ts
@@ -13,6 +13,10 @@ export interface NetworkConfig {
 
 export type Networks = {[key: string]: NetworkConfig}
 
+export function isNetworkConfig(cand: any): cand is NetworkConfig {
+  return cand && cand.chainId !== undefined
+}
+
 export const ethereumNetworks: Networks = {
   mainnet: {
     name: 'mainnet',

--- a/packages/wallet/src/signer.ts
+++ b/packages/wallet/src/signer.ts
@@ -1,7 +1,16 @@
-import { Signer as AbstractSigner } from 'ethers'
+import { NetworkConfig } from '@0xsequence/network'
+import { Transactionish } from '@0xsequence/transactions'
+import { TransactionResponse } from '@ethersproject/providers'
+import { BigNumberish, Signer as AbstractSigner } from 'ethers'
+import { BytesLike, Deferrable } from 'ethers/lib/utils'
+import { WalletConfig } from '.'
 
 export abstract class Signer extends AbstractSigner {
-  // TODO .....
+  abstract getSigners(): Promise<string[]>
+  abstract sendTransaction(transaction: Deferrable<Transactionish>, allSigners?: boolean): Promise<TransactionResponse>
+  abstract signMessage(message: BytesLike, chainId?: NetworkConfig | BigNumberish, allSigners?: boolean): Promise<string>
+  abstract updateConfig(newConfig: WalletConfig): Promise<[WalletConfig, TransactionResponse | undefined]>
+  abstract publishConfig(): Promise<TransactionResponse>
 }
 
 export type SignerThreshold = {

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -2,12 +2,11 @@ import {
   Provider,
   TransactionResponse,
   BlockTag,
-  ExternalProvider,
   JsonRpcProvider,
   TransactionRequest
 } from '@ethersproject/providers'
 import { BigNumber, BigNumberish, ethers, Signer as AbstractSigner } from 'ethers'
-import { Interface, ConnectionInfo, BytesLike, Deferrable, resolveProperties } from 'ethers/lib/utils' 
+import { Interface, ConnectionInfo, BytesLike, Deferrable } from 'ethers/lib/utils' 
 
 import { walletContracts } from '@0xsequence/abi'
 
@@ -26,7 +25,7 @@ import {
 
 import { Relayer } from '@0xsequence/relayer'
 
-import { WalletContext, JsonRpcSender } from '@0xsequence/network'
+import { WalletContext, JsonRpcSender, NetworkConfig, isNetworkConfig } from '@0xsequence/network'
 
 import {
   WalletConfig,
@@ -222,13 +221,13 @@ export class Wallet extends Signer {
   // signMessage will sign a message for a particular chainId with the wallet signers
   //
   // NOTE: signMessage(message: Bytes | string): Promise<string> is defined on AbstractSigner
-  async signMessage(message: BytesLike, chainId?: number, allSigners?: boolean): Promise<string> {
+  async signMessage(message: BytesLike, chainId?: NetworkConfig | BigNumberish, allSigners?: boolean): Promise<string> {
     return this.sign(message, false, chainId, allSigners)
   }
 
   // sign is a helper method to sign a payload with the wallet signers
-  async sign(msg: BytesLike, isDigest: boolean = true, chainId?: number, allSigners?: boolean): Promise<string> {
-    const signChainId = chainId ? chainId : await this.chainId()
+  async sign(msg: BytesLike, isDigest: boolean = true, chainId?: NetworkConfig | BigNumberish, allSigners?: boolean): Promise<string> {
+    const signChainId = chainId ? isNetworkConfig(chainId) ? chainId.chainId : BigNumber.from(chainId) : await this.chainId()
     const digest = ethers.utils.arrayify(isDigest ? msg :
       ethers.utils.keccak256(
         packMessageData(


### PR DESCRIPTION
:warning: This PR changes the interface for MultiWallet `sendTransaction`:

prev:
```ts
async sendTransaction(dtransactionish: Deferrable<Transactionish>, network?: NetworkConfig | BigNumberish, onlyFullSign: boolean = true): Promise<TransactionResponse>
```

new:
```ts
async sendTransaction(dtransactionish: Deferrable<Transactionish>, onlyFullSign: boolean = true, network?: NetworkConfig | BigNumberish): Promise<TransactionResponse>
```