### PR TITLE
report getStorageAt issue with hardhat, versus ganache or other eth nodes

### DIFF
--- a/packages/relayer/src/local-relayer.ts
+++ b/packages/relayer/src/local-relayer.ts
@@ -18,13 +18,15 @@ export class LocalRelayer extends BaseRelayer implements Relayer {
   }
 
   async deployWallet(config: WalletConfig, context: WalletContext): Promise<TransactionResponse> {
-    // TODO: some tests, with the HookCallerMock fail without the thing below, perhaps review HookCallerMock.sol
-    // and fix it to avoid what looks like an infinite loop?
+    // TODO: some tests, with the HookCallerMock fail without setting the constant gasLimit below,
+    // perhaps review HookCallerMock.sol and fix it to avoid what looks like an infinite loop in hardhat?
     const walletDeployTxn = this.prepareWalletDeploy(config, context)
 
-    // NOTE: for hardhat to pass, we have to set the gasLimit directly, as its unable to estimate
-    // return this.signer.sendTransaction({ ...walletDeployTxn, gasLimit: ethers.constants.Two.pow(17) } )
-    return this.signer.sendTransaction(walletDeployTxn)
+    // NOTE: for hardhat to pass, we have to set the gasLimit directly, as its unable to estimate.
+    // However, setting a constant gasLimit is also okay, as it saves us a step for what is
+    // a constant value for every wallet deployment.
+    return this.signer.sendTransaction({ ...walletDeployTxn, gasLimit: ethers.constants.Two.pow(17) } )
+    // return this.signer.sendTransaction(walletDeployTxn)
   }
 
   async gasRefundOptions(

--- a/packages/wallet/tests/wallet.spec.ts
+++ b/packages/wallet/tests/wallet.spec.ts
@@ -1258,7 +1258,7 @@ describe('Wallet integration', function () {
 
       const updatedWallet = new lib.Wallet(config, context, s1).connect(ganache.provider, relayer)
 
-      expect(ethers.utils.getAddress(await ganache.provider.getStorageAt(wallet.address, wallet.address)))
+      expect(ethers.utils.defaultAbiCoder.decode(['address'], await ganache.provider.getStorageAt(wallet.address, wallet.address))[0])
         .to.equal(ethers.utils.getAddress(context.mainModuleUpgradable))
 
       expect(updatedWallet.address).to.be.equal(wallet.address)
@@ -1289,7 +1289,7 @@ describe('Wallet integration', function () {
 
       const updatedWallet = new lib.Wallet(config, context, s1, s2).connect(ganache.provider, relayer)
 
-      expect(ethers.utils.getAddress(await ganache.provider.getStorageAt(wallet.address, wallet.address)))
+      expect(ethers.utils.defaultAbiCoder.decode(['address'], await ganache.provider.getStorageAt(wallet.address, wallet.address))[0])
         .to.equal(ethers.utils.getAddress(context.mainModuleUpgradable))
 
       expect(updatedWallet.address).to.be.equal(wallet.address)
@@ -1363,7 +1363,7 @@ describe('Wallet integration', function () {
   
         const updatedWallet = new lib.Wallet(config, context, s1).connect(ganache.provider, relayer)
   
-        expect(ethers.utils.getAddress(await ganache.provider.getStorageAt(wallet2.address, wallet2.address)))
+        expect(ethers.utils.defaultAbiCoder.decode(['address'], await ganache.provider.getStorageAt(wallet.address, wallet.address))[0])
           .to.equal(ethers.utils.getAddress(context.mainModuleUpgradable))
   
         expect(updatedWallet.address).to.be.equal(wallet2.address)
@@ -1394,7 +1394,7 @@ describe('Wallet integration', function () {
   
         const updatedWallet = new lib.Wallet(config, context, s1, s2).connect(ganache.provider, relayer)
   
-        expect(ethers.utils.getAddress(await ganache.provider.getStorageAt(wallet2.address, wallet2.address)))
+        expect(ethers.utils.defaultAbiCoder.decode(['address'], await ganache.provider.getStorageAt(wallet.address, wallet.address))[0])
           .to.equal(ethers.utils.getAddress(context.mainModuleUpgradable))
   
         expect(updatedWallet.address).to.be.equal(wallet2.address)

--- a/packages/wallet/tests/wallet.spec.ts
+++ b/packages/wallet/tests/wallet.spec.ts
@@ -30,7 +30,7 @@ const { expect } = chai.use(chaiAsPromised)
 
 import hardhat from 'hardhat'
 
-const GANACHE_PORT = 38545
+const GANACHE_PORT = 8545
 
 type GanacheInstance = {
   server?: any
@@ -68,23 +68,26 @@ describe('Wallet integration', function () {
     //--
     // Ganache version
     ganache.chainId = 31337
-    ganache.server = Ganache.server({
-      _chainIdRpc: ganache.chainId,
-      _chainId: ganache.chainId,
-      mnemonic: "ripple axis someone ridge uniform wrist prosper there frog rate olympic knee"
-    })
+    // ganache.server = Ganache.server({
+    //   _chainIdRpc: ganache.chainId,
+    //   _chainId: ganache.chainId,
+    //   mnemonic: "ripple axis someone ridge uniform wrist prosper there frog rate olympic knee"
+    // })
 
-    await ganache.server.listen(GANACHE_PORT)
+    // await ganache.server.listen(GANACHE_PORT)
 
     ganache.serverUri = `http://localhost:${GANACHE_PORT}/`
     ganache.provider = new JsonRpcProvider(`http://localhost:${GANACHE_PORT}/`, { name: 'wee', chainId: 31337 })
     ganache.signer = ganache.provider.getSigner()
+
+
+
     //--
 
     // --
     // Hardhat version
     // NOTE: as well LocalRelayer deploy wallet method must set gasLimit directly or it will blow up.
-    // hardhat.config.networks.ganache = hardhat.config.networks.hardhat
+    hardhat.config.networks.ganache = hardhat.config.networks.hardhat
     // ganache.provider = new Web3Provider(hardhat.network.provider.send, { name: 'hardhat', chainId: 31337 })
     // ganache.signer = ganache.provider.getSigner()
     //--
@@ -220,9 +223,6 @@ describe('Wallet integration', function () {
 
             // Contract wallet must be deployed before calling ERC1271
             const txn = await relayer.deployWallet(wallet.config, context)
-
-            // const receipt = await provider.getTransactionReceipt(txn.hash)
-            // console.log('status?', receipt.status)
 
             const call = hookCaller.callERC1271isValidSignatureData(wallet.address, message, signature)
             await expect(call).to.be.fulfilled


### PR DESCRIPTION
1. clone the repo and `cd arcadeum.js`
2. `git checkout hardhat-bug`
3. `yarn install`
4. in one terminal: `cd packages/0xsequence; yarn start:hardhat:verbose`
5. in another terminal: `cd packages/wallet; yarn test`

you will see similar output to below screenshot in comment. However, if you change step 4 above to `yarn start:ganache`, you shall see tests will pass